### PR TITLE
Fixed bug in getMarketItems()

### DIFF
--- a/contracts/Marketplace/Marketplace.sol
+++ b/contracts/Marketplace/Marketplace.sol
@@ -501,7 +501,7 @@ contract Marketplace is ERC1155Holder, Context {
   function getMarketItems(uint256[] memory _itemIDs) public view returns (MarketItem[] memory marketItems_) {
     marketItems_ = new MarketItem[](_itemIDs.length);
     for (uint256 i = 0; i < _itemIDs.length; i++) {
-      marketItems_[i] = marketItems[_itemIDs[i]];
+      marketItems_[i] = marketItems[_itemIDs[i] - 1];
     }
   }
 


### PR DESCRIPTION
There's a huge bug on line 504: marketItems[_itemIDs[i]], which is supposed to be marketItems[_itemIDs[i] - 1]. I'm not sure if we want to use the deploy branch for contracts that are already deployed, or if it's for contracts that are ready to be deployed--if it's the former then let's make this change to the most recent branch, if it's the latter then let's accept this change.